### PR TITLE
B fix typo in actionspace

### DIFF
--- a/droid/franka/robot.py
+++ b/droid/franka/robot.py
@@ -186,7 +186,7 @@ class FrankaRobot:
 
         if gripper_action_space is None:
             gripper_action_space = "velocity" if velocity else "position"
-        assert gripper_action_space in ["velocity", "policy"]
+        assert gripper_action_space in ["velocity", "position"]
             
 
         if gripper_action_space == "velocity":

--- a/droid/misc/server_interface.py
+++ b/droid/misc/server_interface.py
@@ -43,7 +43,7 @@ class ServerInterface:
         self.server.kill_controller()
 
     def update_command(self, command, action_space="cartesian_velocity", gripper_action_space="velocity", blocking=False):
-        action_dict = self.server.update_command(command.tolist(), action_space, blocking)
+        action_dict = self.server.update_command(command.tolist(), action_space, gripper_action_space, blocking)
         return action_dict
 
     def create_action_dict(self, command, action_space="cartesian_velocity"):


### PR DESCRIPTION
it seems that there is a typo in this assert, I also found that in server interface the gripper_action_space wasn't being passed which resulted in the blocking value of 'False' being assigned to the gripper_action_space when received on the client side (robot). When calibrating the gripper action space was set to position which threw this assert.