### PR TITLE
Fix Franka Pricing

### DIFF
--- a/docs/hardware-setup/shopping-list.md
+++ b/docs/hardware-setup/shopping-list.md
@@ -13,7 +13,7 @@ nav_order: 1
 
 | Component | Quantity | Approximate Component Cost | Suppliers |
 | --------- | -------- | -------------------------- | --------- |
-| Franka Emika Panda (or) Franka Research 3 | 1 | $10,500 | [Franka Robotics](https://lp.franka.de/request-a-quote) |
+| Franka Emika Panda (or) Franka Research 3 | 1 | ~$28,820.23 | [Franka Robotics](https://lp.franka.de/request-a-quote) |
 
 ## Gripper:
 


### PR DESCRIPTION
This pull request updates the pricing associated with Franka robot in the shopping list. The update uses the price quoted by official UK reseller [bots.co.uk](https://bots.co.uk/cobots/university-research-robots/#:~:text=Price%20Starting%20From%20%C2%A322500%20exc%20VAT) for the Franka Research 3 (FR3) and is converted to USD. 

The actual quote value for USD amount may vary, if anyone has a recent quote I will update the PR with this figure. 