### PR TITLE
Fix documented action layout

### DIFF
--- a/docs/the-droid-dataset.md
+++ b/docs/the-droid-dataset.md
@@ -76,7 +76,7 @@ DROID = {
                 		},
 		"discount": tf.Scalar(dtype=float32), # discount if provided, default to 1
                 "reward": tf.Scalar(dtype=float32), # reward if provided, 1 on final step for demos
-                "action": tf.Tensor(7, dtype=float64), # robot action, consists of [6x joint velocities, 1x gripper position]
+                "action": tf.Tensor(7, dtype=float64), # robot action, consists of [6x commanded Cartesian position, 1x commanded gripper position]
 	},
 }
 ```


### PR DESCRIPTION
## What

Correct the documented seven-value `action` layout from six joint velocities plus gripper position to six commanded Cartesian-position values plus commanded gripper position.

## Evidence

The pinned dataset-builder implementation constructs `action` with:

```python
np.concatenate((action['cartesian_position'], [action['gripper_position']]))
```

See [`droid.py` lines 69–77](https://github.com/kpertsch/droid_dataset_builder/blob/8c3f83f3dfa490e670002886907f96914c5961a2/droid/droid.py#L69-L77). The same builder's feature documentation currently carries the joint-velocity wording, so the generated `features.json` inherited it.

I also decoded all 100 episodes in the official `droid_100/1.0.0` sample and compared every step. All **32,212/32,212** `action` vectors exactly equal the six-value `action_dict.cartesian_position` concatenated with the one-value `action_dict.gripper_position`; the maximum absolute difference is **0**. `action` differs from `action_dict.joint_velocity` (maximum absolute difference **4.125915944576263**).

The machine-readable audit, pinned object generations/checksums, and RFC 6902 metadata patch are published in [`droid-quality-audit` v0.1.0](https://github.com/sawhney17/droid-quality-audit/releases/tag/v0.1.0):

- [all-step action/reward audit](https://github.com/sawhney17/droid-quality-audit/blob/v0.1.0/data/schema_fixes/action_reward_audit.json)
- [description patch](https://github.com/sawhney17/droid-quality-audit/blob/v0.1.0/data/schema_fixes/features_description_fix.json)
- [source-object lock](https://github.com/sawhney17/droid-quality-audit/blob/v0.1.0/data/manifests/source_objects.json)

## Scope

This PR changes one documentation line only. It does not alter stored dataset values or claim that the action is Cartesian velocity.
